### PR TITLE
Propagate callback error through

### DIFF
--- a/python/src/pynumbuf/adapters/numpy.cc
+++ b/python/src/pynumbuf/adapters/numpy.cc
@@ -117,7 +117,7 @@ Status SerializeArray(PyArrayObject* array, SequenceBuilder& builder,
         PyObject* result = PyObject_CallObject(numbuf_serialize_callback, arglist);
         if (!result) {
           Py_XDECREF(arglist);
-          return python_error_to_status();
+          return Status::NotImplemented("python error"); // TODO(pcm): https://github.com/pcmoritz/numbuf/issues/10
         }
         builder.AppendDict(PyDict_Size(result));
         subdicts.push_back(result);

--- a/python/src/pynumbuf/adapters/python.h
+++ b/python/src/pynumbuf/adapters/python.h
@@ -17,8 +17,6 @@ arrow::Status DeserializeList(std::shared_ptr<arrow::Array> array, int32_t start
 arrow::Status DeserializeTuple(std::shared_ptr<arrow::Array> array, int32_t start_idx, int32_t stop_idx, PyObject* base, PyObject** out);
 arrow::Status DeserializeDict(std::shared_ptr<arrow::Array> array, int32_t start_idx, int32_t stop_idx, PyObject* base, PyObject** out);
 
-arrow::Status python_error_to_status();
-
 }
 
 #endif


### PR DESCRIPTION
This PR modifies numbuf so that errors that occur in the serialization callback are propagated to the user.

To try this out, run the following:

``` python
import libnumbuf
import numpy as np

def serialize(obj):
  raise Exception("this is an error")

libnumbuf.register_callbacks(serialize, serialize)

libnumbuf.serialize_list([np.array([1, 2], dtype=object)])
```
