### PR TITLE
Added serializability of dicts and lists as keys in a dict.

### DIFF
--- a/cpp/src/numbuf/dict.cc
+++ b/cpp/src/numbuf/dict.cc
@@ -5,13 +5,15 @@ using namespace arrow;
 namespace numbuf {
 
 std::shared_ptr<arrow::StructArray> DictBuilder::Finish(
+    std::shared_ptr<Array> key_list_data,
     std::shared_ptr<Array> key_tuple_data,
+    std::shared_ptr<Array> key_dict_data,
     std::shared_ptr<Array> val_list_data,
     std::shared_ptr<Array> val_tuple_data,
     std::shared_ptr<Array> val_dict_data) {
   // lists and dicts can't be keys of dicts in Python, that is why for
   // the keys we do not need to collect sublists
-  auto keys = keys_.Finish(nullptr, key_tuple_data, nullptr);
+  auto keys = keys_.Finish(key_list_data, key_tuple_data, key_dict_data);
   auto vals = vals_.Finish(val_list_data, val_tuple_data, val_dict_data);
   auto keys_field = std::make_shared<Field>("keys", keys->type());
   auto vals_field = std::make_shared<Field>("vals", vals->type());

--- a/cpp/src/numbuf/dict.h
+++ b/cpp/src/numbuf/dict.h
@@ -34,7 +34,9 @@ public:
         value list of the dictionary
   */
   std::shared_ptr<arrow::StructArray> Finish(
+    std::shared_ptr<arrow::Array> key_list_data,
     std::shared_ptr<arrow::Array> key_tuple_data,
+    std::shared_ptr<arrow::Array> key_dict_data,
     std::shared_ptr<arrow::Array> val_list_data,
     std::shared_ptr<arrow::Array> val_tuple_data,
     std::shared_ptr<arrow::Array> val_dict_data);


### PR DESCRIPTION
Though in normal python, we cannot use dictionaries as keys for dictionaries. However, for supporting custom classes, we expand these classes out to dictionaries of their attributes. Thus, if a custom class instance is used as a key for a dictionary, we need this functionality.
