### PR TITLE
Limit recursion depth for serializing objects to avoid infinite loops.

### DIFF
--- a/python/src/pynumbuf/adapters/python.h
+++ b/python/src/pynumbuf/adapters/python.h
@@ -11,8 +11,8 @@
 
 namespace numbuf {
 
-arrow::Status SerializeSequences(std::vector<PyObject*> sequences, std::shared_ptr<arrow::Array>* out);
-arrow::Status SerializeDict(std::vector<PyObject*> dicts, std::shared_ptr<arrow::Array>* out);
+arrow::Status SerializeSequences(std::vector<PyObject*> sequences, int32_t recursion_depth, std::shared_ptr<arrow::Array>* out);
+arrow::Status SerializeDict(std::vector<PyObject*> dicts, int32_t recursion_depth, std::shared_ptr<arrow::Array>* out);
 arrow::Status DeserializeList(std::shared_ptr<arrow::Array> array, int32_t start_idx, int32_t stop_idx, PyObject* base, PyObject** out);
 arrow::Status DeserializeTuple(std::shared_ptr<arrow::Array> array, int32_t start_idx, int32_t stop_idx, PyObject* base, PyObject** out);
 arrow::Status DeserializeDict(std::shared_ptr<arrow::Array> array, int32_t start_idx, int32_t stop_idx, PyObject* base, PyObject** out);

--- a/python/src/pynumbuf/numbuf.cc
+++ b/python/src/pynumbuf/numbuf.cc
@@ -51,7 +51,8 @@ static PyObject* serialize_list(PyObject* self, PyObject* args) {
   }
   std::shared_ptr<Array> array;
   if (PyList_Check(value)) {
-    Status s = SerializeSequences(std::vector<PyObject*>({value}), &array);
+    int32_t recursion_depth = 0;
+    Status s = SerializeSequences(std::vector<PyObject*>({value}), recursion_depth, &array);
     if (!s.ok()) {
       // If this condition is true, there was an error in the callback that
       // needs to be passed through


### PR DESCRIPTION
This is an attempt to prevent infinite loops from recursive objects during serialization. For example,

``` python
import libnumbuf

l = []
l.append(l)
libnumbuf.serialize_list([l])
```

Throws an exception

``` python
error: NotImplemented: This object exceeds the maximum recursion depth. It may contain itself recursively.
```
